### PR TITLE
chore: add CODEOWNERS file to define code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@irvanrizkin @Aldi-H

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@irvanrizkin @Aldi-H
+* @irvanrizkin @Aldi-H


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds `@irvanrizkin` and `@Aldi-H` as code owners.